### PR TITLE
feat(rbac): enforce LumApps-native permissions and tighten content/structural tool governance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,15 +53,16 @@ SITE_BASE_URL=https://sites.lumapps.com
 
 # --- RBAC (user-level role checks for Content/Structural tools) ---
 # RBAC_ENABLED=true
-# Claim name for role/groups (e.g. groups, roles)
+# Use LumApps native permissions (front-init, content/get canEdit, and LumApps token payload isOrgAdmin)
+# RBAC_USE_LUMAPPS_NATIVE=true
+# Claim in LumApps user token payload for platform Global Admin (e.g. isOrgAdmin: true)
+# RBAC_ORG_ADMIN_CLAIM=isOrgAdmin
+# Fallback when RBAC_USE_LUMAPPS_NATIVE=false: claim and patterns below
 # RBAC_ROLE_CLAIM=groups
-# Patterns: {site_id} replaced by target site; comma-separated. Global admin: use literal * (e.g. lumapps:site:*:admin)
 # RBAC_ADMIN_PATTERNS=lumapps:site:{site_id}:admin
 # RBAC_CONTRIBUTOR_PATTERNS=lumapps:site:{site_id}:contributor,lumapps:site:{site_id}:admin
 # RBAC_GLOBAL_ADMIN_PATTERNS=lumapps:site:*:admin,lumapps:global:admin
-# Deny Content/Structural tools when authenticated with API key only (no OIDC identity)
 # RBAC_DENY_API_KEY_FOR_NON_READ=true
-# Content -> site resolution cache (TTL seconds, max entries)
 # RBAC_CONTENT_SITE_CACHE_TTL_SECONDS=300
 # RBAC_CONTENT_SITE_CACHE_MAX_SIZE=500
 

--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,20 @@ LUMAPPS_ORG_ID=your-organization-id
 LUMAPPS_HAUSSMANN_CELL=https://go-cell-003.beta.api.lumapps.com
 SITE_BASE_URL=https://sites.lumapps.com
 
+# --- RBAC (user-level role checks for Content/Structural tools) ---
+# RBAC_ENABLED=true
+# Claim name for role/groups (e.g. groups, roles)
+# RBAC_ROLE_CLAIM=groups
+# Patterns: {site_id} replaced by target site; comma-separated. Global admin: use literal * (e.g. lumapps:site:*:admin)
+# RBAC_ADMIN_PATTERNS=lumapps:site:{site_id}:admin
+# RBAC_CONTRIBUTOR_PATTERNS=lumapps:site:{site_id}:contributor,lumapps:site:{site_id}:admin
+# RBAC_GLOBAL_ADMIN_PATTERNS=lumapps:site:*:admin,lumapps:global:admin
+# Deny Content/Structural tools when authenticated with API key only (no OIDC identity)
+# RBAC_DENY_API_KEY_FOR_NON_READ=true
+# Content -> site resolution cache (TTL seconds, max entries)
+# RBAC_CONTENT_SITE_CACHE_TTL_SECONDS=300
+# RBAC_CONTENT_SITE_CACHE_MAX_SIZE=500
+
 # App
 LOG_LEVEL=INFO
 MAX_SEARCH_RESULTS=5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **RBAC LumApps native permissions**: when `RBAC_USE_LUMAPPS_NATIVE=true` (default), permissions use LumApps APIs and the LumApps user token payload. **Global Admin**: claim `isOrgAdmin: true` in the **LumApps user token** (obtained via impersonation), not in the OIDC JWT (`RBAC_ORG_ADMIN_CLAIM`). **Site Admin (Structural)**: `GET service/front-init?fields=user` → `user.instancesSuperAdmin`, `user.isSuperAdmin`. **Content (canEdit)**: `GET content/get?uid=...&fields=canEdit`. Fallback to OIDC role patterns when `RBAC_USE_LUMAPPS_NATIVE=false`.
+- **User-level RBAC**: tool execution is gated by authenticated user role, not just app credentials. Read tools remain available to all; **Content** tools (`inspect_lumapps_element`, `update_widget_style`) require Contributor or Admin for the target page/site; **Structural** tools (`update_global_css`, `update_site_global_settings`) require Site Administrator for the target site. Global Admin is supported via a single claim (e.g. `lumapps:site:*:admin`) so tokens do not list hundreds of sites. OIDC role patterns are configurable (`RBAC_ADMIN_PATTERNS`, `RBAC_CONTRIBUTOR_PATTERNS`, `RBAC_GLOBAL_ADMIN_PATTERNS`). When `RBAC_DENY_API_KEY_FOR_NON_READ=true`, API key alone cannot run Content or Structural tools. A short TTL cache resolves `content_id` → `site_id` for widget updates. See README (User-level RBAC).
 - **OIDC (SSO) authentication**: provider-agnostic OpenID Connect support so the server can authenticate users via corporate IdPs (Azure AD / Entra ID, Okta, Ping Identity). Bearer tokens are validated (signature via JWKS, issuer, audience, expiry) and identity is bound to tool execution.
 - **Dual-mode MCP auth**: `AUTH_MODE=oidc_preferred` (default) tries Bearer as OIDC JWT first, then falls back to static API key when `AUTH_ALLOW_API_KEY_FALLBACK=true`. `AUTH_MODE=api_key_only` keeps legacy API-key-only behavior.
 - **UserContext and verified identity**: when OIDC succeeds, `user_email` is resolved from token claims (`email`, `preferred_username`, `upn`) and injected into tool calls; client-supplied `user_email` is rejected if it does not match the token.
@@ -28,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **Verified user identity**: every tool call when using OIDC is tied to the authenticated user from the IdP; no client-controlled `user_email` in that mode.
+- **RBAC**: Structural and Content tools require OIDC identity and the appropriate site role (or Global Admin); API key is read-only when RBAC is enabled. LumApps 401/403 on writes are surfaced as governance-friendly messages.
 - Container runs as non-root user (UID/GID 1000).
 - Credentials injected via environment only (ConfigMap/Secret); no hardcoded secrets in image.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ cp .env.example .env
    - `OIDC_ISSUER_URL`, `OIDC_AUDIENCE`, `OIDC_CLIENT_ID`, `OIDC_EMAIL_CLAIM`, `OIDC_USERNAME_CLAIM`, `OIDC_CLOCK_SKEW_SECONDS`: see [SSO / OIDC](#sso--oidc-enterprise) and `.env.example`.
    - `MCP_PUBLIC_URL`: public server URL (e.g. devtunnel/ngrok) so clients get the correct URL in MCP events.
    - `LUMAPPS_ADMIN_CLIENT_ID` + `LUMAPPS_ADMIN_CLIENT_SECRET`: second LumApps OAuth app with **all.admin** scope (see [Read vs admin credentials](#read-vs-admin-credentials) below).
-   - **RBAC** (see [User-level RBAC](#user-level-rbac)): `RBAC_ENABLED`, `RBAC_ROLE_CLAIM`, `RBAC_ADMIN_PATTERNS`, `RBAC_CONTRIBUTOR_PATTERNS`, `RBAC_GLOBAL_ADMIN_PATTERNS`, `RBAC_DENY_API_KEY_FOR_NON_READ`, `RBAC_CONTENT_SITE_CACHE_TTL_SECONDS`, `RBAC_CONTENT_SITE_CACHE_MAX_SIZE`.
+   - **RBAC** (see [User-level RBAC](#user-level-rbac)): `RBAC_ENABLED`, `RBAC_USE_LUMAPPS_NATIVE`, `RBAC_ORG_ADMIN_CLAIM`, and (fallback) `RBAC_ROLE_CLAIM`, `RBAC_*_PATTERNS`, `RBAC_DENY_API_KEY_FOR_NON_READ`, `RBAC_CONTENT_SITE_CACHE_*`.
    - `CORS_ORIGINS`: extra CORS origins (comma-separated).
    - `LOG_LEVEL`, `MAX_SEARCH_RESULTS`, etc.
 
@@ -88,11 +88,11 @@ LumApps OAuth applications are created with a fixed scope: **all.read** (read-on
 
 | Purpose                   | Env vars                                                                                                   | LumApps scope | Tools                                                                                                             |
 | ------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------- |
-| **Read (end users)**      | `LUMAPPS_READ_CLIENT_ID` + `LUMAPPS_READ_CLIENT_SECRET` (or `LUMAPPS_CLIENT_ID` + `LUMAPPS_CLIENT_SECRET`) | **all.read**  | `search_content`, `get_content_body`, `find_person`, `get_useful_links`, `search_site`, `inspect_lumapps_element` |
-| **Admin (modifications)** | `LUMAPPS_ADMIN_CLIENT_ID` + `LUMAPPS_ADMIN_CLIENT_SECRET`                                                  | **all.admin** | `update_global_css`, `update_widget_style`, `update_site_global_settings`                                         |
+| **Read (end users)**      | `LUMAPPS_READ_CLIENT_ID` + `LUMAPPS_READ_CLIENT_SECRET` (or `LUMAPPS_CLIENT_ID` + `LUMAPPS_CLIENT_SECRET`) | **all.read**  | `search_content`, `get_content_body`, `find_person`, `get_useful_links`, `search_site`                             |
+| **Admin (content + structural)** | `LUMAPPS_ADMIN_CLIENT_ID` + `LUMAPPS_ADMIN_CLIENT_SECRET`                                            | **all.admin** | `inspect_lumapps_element`, `update_widget_style`, `update_global_css`, `update_site_global_settings`                 |
 
 - **Recommended setup**: Create **two OAuth applications** in LumApps for the same organization: one with **all.read** (for end-user search and inspection), one with **all.admin** (for CSS and widget updates). Set the read app in `LUMAPPS_READ_CLIENT_ID`/`LUMAPPS_READ_CLIENT_SECRET` (or legacy `LUMAPPS_CLIENT_ID`/`LUMAPPS_CLIENT_SECRET`) and the admin app in `LUMAPPS_ADMIN_CLIENT_ID`/`LUMAPPS_ADMIN_CLIENT_SECRET`. The server will use the read app for read tools and the admin app for modification tools; tokens are cached per user and per profile.
-- **Read-only deployment**: If you only set the read credentials, **modification tools will not work**. Calling `update_global_css`, `update_widget_style` or `update_site_global_settings` will return a clear error asking you to configure the admin credentials.
+- **Read-only deployment**: If you only set the read credentials, **inspect and modification tools will not work**. `inspect_lumapps_element`, `update_global_css`, `update_widget_style` and `update_site_global_settings` require the admin app; calling them without admin credentials will return a clear error.
 - **Single token (tests)**: If you set `LUMAPPS_ACCESS_TOKEN`, that token is used for both read and admin; no separate admin credentials are needed. The token must have the scope required by the tools you use (admin scope if you call modification tools).
 
 ---
@@ -160,19 +160,20 @@ Credentials stay inside your perimeter; use your existing secret management (e.g
 
 ## Exposed MCP tools
 
-| Tool                          | Description                                                                  | Credentials       |
-| ----------------------------- | ---------------------------------------------------------------------------- | ----------------- |
-| `search_content`              | Search LumApps content (titles, excerpts, `content_id`)                      | read (all.read)   |
-| `get_content_body`            | Get full article body by `content_id`                                        | read              |
-| `find_person`                 | Search people in the directory                                               | read              |
-| `get_useful_links`            | Search useful links (Directory Entries: train, IT, training, etc.)           | read              |
-| `search_site`                 | List or search LumApps sites (instances) for discovery and user confirmation | read              |
-| `inspect_lumapps_element`     | Inspect page layout or site global CSS (API only)                            | read              |
-| `update_global_css`           | Update site global CSS                                                       | admin (all.admin) |
-| `update_widget_style`         | Update a widget's style on a page                                            | admin             |
-| `update_site_global_settings` | Update site footer HTML and/or head scripts                                  | admin             |
+| Tool                          | Description                                                                  | Level      | LumApps credentials   |
+| ----------------------------- | ---------------------------------------------------------------------------- | ---------- | --------------------- |
+| `search_content`              | Search LumApps content (titles, excerpts, `content_id`)                      | Read       | read (all.read)        |
+| `get_content_body`            | Get full article body by `content_id`                                        | Read       | read                   |
+| `find_person`                 | Search people in the directory                                               | Read       | read                   |
+| `get_useful_links`            | Search useful links (Directory Entries: train, IT, training, etc.)           | Read       | read                   |
+| `search_site`                 | List or search LumApps sites (instances) for discovery and user confirmation | Read       | read                   |
+| `inspect_lumapps_element`     | Inspect page layout or site global CSS (API only); prepares edits           | **Content** | admin (canEdit/site admin)      |
+| `update_global_css`           | Update site global CSS                                                       | Structural | admin (all.admin)     |
+| `update_widget_style`         | Update a widget's style on a page                                            | Content    | admin + canEdit       |
+| `update_site_global_settings` | Update site footer HTML and/or head scripts                                  | Structural | admin                 |
 
-Read tools use the **read** LumApps app (`LUMAPPS_READ_CLIENT_ID`/`LUMAPPS_READ_CLIENT_SECRET` or `LUMAPPS_CLIENT_ID`/`LUMAPPS_CLIENT_SECRET`); modification tools use the **admin** app (`LUMAPPS_ADMIN_CLIENT_ID`/`LUMAPPS_ADMIN_CLIENT_SECRET`) when configured. See [Read vs admin credentials](#read-vs-admin-credentials). When [user-level RBAC](#user-level-rbac) is enabled, **Structural** tools (CSS, layout, global settings) also require the authenticated user to have Site Administrator role for the target site; **Content** tools (when added) require Contributor or Admin. API key alone cannot run Structural or Content tools.
+- **Level**: RBAC sensitivity. **Read** = any authenticated user. **Content** = Contributor or Admin on the page/site (inspect + widget style). **Structural** = Site Administrator only (global CSS, global settings).
+- **LumApps credentials**: **Read**-level tools use the **read** app. **Content** (`inspect_lumapps_element`, `update_widget_style`) and **Structural** tools use the **admin** app (`LUMAPPS_ADMIN_CLIENT_ID`/`LUMAPPS_ADMIN_CLIENT_SECRET`) when configured. See [Read vs admin credentials](#read-vs-admin-credentials). When [user-level RBAC](#user-level-rbac) is enabled, API key alone cannot run Content or Structural tools.
 
 ### Conduct rules for modification tools
 
@@ -213,13 +214,31 @@ Content is stored in `app/resources/` and can be updated without code changes.
 
 ### User-level RBAC
 
-The server enforces **user-level** role checks so that LumApps governance is respected when using AI agents:
+The server enforces **user-level** role checks so that LumApps governance is respected when using AI agents. When **`RBAC_USE_LUMAPPS_NATIVE=true`** (default), permissions are based on **LumApps native APIs** and **OIDC**, avoiding reliance on a single "all.admin" token:
 
-- **Read tools**: available to any authenticated user (API key or OIDC).
-- **Content tools** (draft/edit pages or articles, when added): require **Contributor** or **Admin** role for the target site; OIDC identity required (API key alone is denied when `RBAC_DENY_API_KEY_FOR_NON_READ=true`).
-- **Structural tools** (`update_global_css`, `update_site_global_settings`, `update_widget_style`): require **Site Administrator** role for the target site. A **Global Admin** (e.g. one JWT claim such as `lumapps:site:*:admin` or `lumapps:global:admin`) is allowed on all sites without listing each site in the token.
+- **Global Admin (Platform)**: **LumApps user token** payload (the token obtained via impersonation) must contain **`isOrgAdmin: true`** (configurable via `RBAC_ORG_ADMIN_CLAIM`). That token is generated from OAuth2 client credentials + user email; the claim comes from LumApps, not from the OIDC JWT.
+- **Site Admin (Structural tools)**: LumApps **`GET service/front-init?fields=user`** returns `user.instancesSuperAdmin` (site IDs where the user is admin) and `user.isSuperAdmin`. The user must be in that list (or `isSuperAdmin`) for `update_global_css` and `update_site_global_settings`.
+- **Content Editor (Content tools)**: LumApps **`GET content/get?uid=...&fields=canEdit`** returns whether the user can edit that page. Used for `inspect_lumapps_element` and `update_widget_style` when targeting a specific content; when only a site is targeted (e.g. inspect global CSS), Site Admin is required.
 
-Role resolution uses OIDC claims (e.g. `groups`). Configure patterns in `RBAC_ADMIN_PATTERNS`, `RBAC_CONTRIBUTOR_PATTERNS`, and `RBAC_GLOBAL_ADMIN_PATTERNS`; use `{site_id}` for site-scoped values and a literal like `lumapps:site:*:admin` for global admin. If LumApps returns 401/403 on a write, the server returns a secure, governance-friendly message instead of raw API details. A short-lived cache (configurable TTL and size) resolves `content_id` → `site_id` for widget updates to avoid repeated LumApps API calls.
+**Read tools** remain available to any authenticated user (API key or OIDC). If LumApps returns 401/403 on a write, the server returns a secure, governance-friendly message. In native mode, if the LumApps user token cannot be obtained for RBAC checks, access is denied (fail-closed). A short-lived cache resolves `content_id` → `site_id` for widget updates.
+
+When **`RBAC_USE_LUMAPPS_NATIVE=false`**, the server falls back to **OIDC role patterns** (`RBAC_ADMIN_PATTERNS`, `RBAC_CONTRIBUTOR_PATTERNS`, `RBAC_GLOBAL_ADMIN_PATTERNS`) with `{site_id}` substitution.
+
+#### Configuring OIDC for RBAC fallback
+
+When using the fallback (no LumApps API for roles), the server reads a **role claim** from the JWT (default: `groups`) and matches its values against the configured patterns. Configure your IdP (Azure AD, Okta, Ping, etc.) so that the token contains the right values:
+
+| Goal | Claim (default `groups`) must contain | Example value |
+|------|----------------------------------------|---------------|
+| **Global Admin** (all tools) | One of `RBAC_GLOBAL_ADMIN_PATTERNS` | `lumapps:site:*:admin` or `lumapps:global:admin` |
+| **Site Admin** (structural tools for a site) | Pattern with concrete `site_id` from `RBAC_ADMIN_PATTERNS` | `lumapps:site:abc123:admin` |
+| **Contributor / Content** (content tools for a site) | Pattern from `RBAC_CONTRIBUTOR_PATTERNS` | `lumapps:site:abc123:contributor` or `lumapps:site:abc123:admin` |
+
+- **Claim name**: Set `RBAC_ROLE_CLAIM` to the claim that holds the list (e.g. `groups`, `roles`, or a custom claim like `lumapps_roles`).
+- **Pattern format**: Patterns use `{site_id}` as placeholder. The server replaces it with the target site ID and checks for an **exact match** in the claim values. For Global Admin, use literal values without placeholder (e.g. `lumapps:site:*:admin`).
+- **IdP setup**: In Azure AD, map LumApps site/role data to group membership or to a custom claim (e.g. via claims mapping policy or SAML/SCIM). In Okta, use groups or a custom claim. Ensure the token actually contains strings like `lumapps:site:<siteId>:admin` for each site where the user is admin.
+
+Example: for a user who is Site Admin on site `prod-portal` and Contributor on site `marketing`, the JWT claim (e.g. `groups`) should include at least `lumapps:site:prod-portal:admin` and `lumapps:site:marketing:contributor` (or `lumapps:site:marketing:admin`).
 
 ### SSO / OIDC (enterprise)
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ cp .env.example .env
    - `OIDC_ISSUER_URL`, `OIDC_AUDIENCE`, `OIDC_CLIENT_ID`, `OIDC_EMAIL_CLAIM`, `OIDC_USERNAME_CLAIM`, `OIDC_CLOCK_SKEW_SECONDS`: see [SSO / OIDC](#sso--oidc-enterprise) and `.env.example`.
    - `MCP_PUBLIC_URL`: public server URL (e.g. devtunnel/ngrok) so clients get the correct URL in MCP events.
    - `LUMAPPS_ADMIN_CLIENT_ID` + `LUMAPPS_ADMIN_CLIENT_SECRET`: second LumApps OAuth app with **all.admin** scope (see [Read vs admin credentials](#read-vs-admin-credentials) below).
+   - **RBAC** (see [User-level RBAC](#user-level-rbac)): `RBAC_ENABLED`, `RBAC_ROLE_CLAIM`, `RBAC_ADMIN_PATTERNS`, `RBAC_CONTRIBUTOR_PATTERNS`, `RBAC_GLOBAL_ADMIN_PATTERNS`, `RBAC_DENY_API_KEY_FOR_NON_READ`, `RBAC_CONTENT_SITE_CACHE_TTL_SECONDS`, `RBAC_CONTENT_SITE_CACHE_MAX_SIZE`.
    - `CORS_ORIGINS`: extra CORS origins (comma-separated).
    - `LOG_LEVEL`, `MAX_SEARCH_RESULTS`, etc.
 
@@ -171,7 +172,7 @@ Credentials stay inside your perimeter; use your existing secret management (e.g
 | `update_widget_style`         | Update a widget's style on a page                       | admin             |
 | `update_site_global_settings` | Update site footer HTML and/or head scripts             | admin             |
 
-Read tools use the **read** LumApps app (`LUMAPPS_READ_CLIENT_ID`/`LUMAPPS_READ_CLIENT_SECRET` or `LUMAPPS_CLIENT_ID`/`LUMAPPS_CLIENT_SECRET`); modification tools use the **admin** app (`LUMAPPS_ADMIN_CLIENT_ID`/`LUMAPPS_ADMIN_CLIENT_SECRET`) when configured. See [Read vs admin credentials](#read-vs-admin-credentials).
+Read tools use the **read** LumApps app (`LUMAPPS_READ_CLIENT_ID`/`LUMAPPS_READ_CLIENT_SECRET` or `LUMAPPS_CLIENT_ID`/`LUMAPPS_CLIENT_SECRET`); modification tools use the **admin** app (`LUMAPPS_ADMIN_CLIENT_ID`/`LUMAPPS_ADMIN_CLIENT_SECRET`) when configured. See [Read vs admin credentials](#read-vs-admin-credentials). When [user-level RBAC](#user-level-rbac) is enabled, **Structural** tools (CSS, layout, global settings) also require the authenticated user to have Site Administrator role for the target site; **Content** tools (when added) require Contributor or Admin. API key alone cannot run Structural or Content tools.
 
 ### Conduct rules for modification tools
 
@@ -205,10 +206,20 @@ Content is stored in `app/resources/` and can be updated without code changes.
 
 - **MCP authentication**: dual mode.
   - **OIDC preferred** (default): send `Authorization: Bearer <user-id-token>` from your IdP (Azure AD, Okta, Ping, etc.). The server validates the JWT (signature, issuer, audience, expiry) and binds every tool call to the verified user; `user_email` is taken from token claims and must not be overridden by the client.
-  - **API key fallback**: when `AUTH_ALLOW_API_KEY_FALLBACK=true`, you can still use `X-API-Key`, `Authorization: Bearer <static-key>`, or query `apiKey` / `token` with `MCP_API_KEY`. For production SSO-only, set `AUTH_ALLOW_API_KEY_FALLBACK=false`.
+  - **API key fallback**: when `AUTH_ALLOW_API_KEY_FALLBACK=true`, you can still use `X-API-Key`, `Authorization: Bearer <static-key>`, or query `apiKey` / `token` with `MCP_API_KEY`. For production SSO-only, set `AUTH_ALLOW_API_KEY_FALLBACK=false`. When [user-level RBAC](#user-level-rbac) is enabled, API key alone is **read-only**: Content and Structural tools are denied and require OIDC identity.
 - **Root endpoint**: `GET /` is unauthenticated (info only). `POST /` accepts JSON-RPC only when authenticated (same as `/mcp`).
 - **Secrets**: no hardcoded secrets; everything comes from config (`pydantic-settings` + `.env`).
 - **`.env`**: for local development only; must not be versioned. In production use environment variables or a secrets store.
+
+### User-level RBAC
+
+The server enforces **user-level** role checks so that LumApps governance is respected when using AI agents:
+
+- **Read tools**: available to any authenticated user (API key or OIDC).
+- **Content tools** (draft/edit pages or articles, when added): require **Contributor** or **Admin** role for the target site; OIDC identity required (API key alone is denied when `RBAC_DENY_API_KEY_FOR_NON_READ=true`).
+- **Structural tools** (`update_global_css`, `update_site_global_settings`, `update_widget_style`): require **Site Administrator** role for the target site. A **Global Admin** (e.g. one JWT claim such as `lumapps:site:*:admin` or `lumapps:global:admin`) is allowed on all sites without listing each site in the token.
+
+Role resolution uses OIDC claims (e.g. `groups`). Configure patterns in `RBAC_ADMIN_PATTERNS`, `RBAC_CONTRIBUTOR_PATTERNS`, and `RBAC_GLOBAL_ADMIN_PATTERNS`; use `{site_id}` for site-scoped values and a literal like `lumapps:site:*:admin` for global admin. If LumApps returns 401/403 on a write, the server returns a secure, governance-friendly message instead of raw API details. A short-lived cache (configurable TTL and size) resolves `content_id` → `site_id` for widget updates to avoid repeated LumApps API calls.
 
 ### SSO / OIDC (enterprise)
 

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ cp .env.example .env
 
 LumApps OAuth applications are created with a fixed scope: **all.read** (read-only) or **all.admin** (read + write). This server separates **end-user tools** (read) from **admin tools** (modifications) by using two credential pairs when both are configured:
 
-| Purpose | Env vars | LumApps scope | Tools |
-|--------|----------|----------------|--------|
-| **Read (end users)** | `LUMAPPS_READ_CLIENT_ID` + `LUMAPPS_READ_CLIENT_SECRET` (or `LUMAPPS_CLIENT_ID` + `LUMAPPS_CLIENT_SECRET`) | **all.read** | `search_content`, `get_content_body`, `find_person`, `get_useful_links`, `search_site`, `inspect_lumapps_element` |
-| **Admin (modifications)** | `LUMAPPS_ADMIN_CLIENT_ID` + `LUMAPPS_ADMIN_CLIENT_SECRET` | **all.admin** | `update_global_css`, `update_widget_style`, `update_site_global_settings` |
+| Purpose                   | Env vars                                                                                                   | LumApps scope | Tools                                                                                                             |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **Read (end users)**      | `LUMAPPS_READ_CLIENT_ID` + `LUMAPPS_READ_CLIENT_SECRET` (or `LUMAPPS_CLIENT_ID` + `LUMAPPS_CLIENT_SECRET`) | **all.read**  | `search_content`, `get_content_body`, `find_person`, `get_useful_links`, `search_site`, `inspect_lumapps_element` |
+| **Admin (modifications)** | `LUMAPPS_ADMIN_CLIENT_ID` + `LUMAPPS_ADMIN_CLIENT_SECRET`                                                  | **all.admin** | `update_global_css`, `update_widget_style`, `update_site_global_settings`                                         |
 
 - **Recommended setup**: Create **two OAuth applications** in LumApps for the same organization: one with **all.read** (for end-user search and inspection), one with **all.admin** (for CSS and widget updates). Set the read app in `LUMAPPS_READ_CLIENT_ID`/`LUMAPPS_READ_CLIENT_SECRET` (or legacy `LUMAPPS_CLIENT_ID`/`LUMAPPS_CLIENT_SECRET`) and the admin app in `LUMAPPS_ADMIN_CLIENT_ID`/`LUMAPPS_ADMIN_CLIENT_SECRET`. The server will use the read app for read tools and the admin app for modification tools; tokens are cached per user and per profile.
 - **Read-only deployment**: If you only set the read credentials, **modification tools will not work**. Calling `update_global_css`, `update_widget_style` or `update_site_global_settings` will return a clear error asking you to configure the admin credentials.
@@ -160,17 +160,17 @@ Credentials stay inside your perimeter; use your existing secret management (e.g
 
 ## Exposed MCP tools
 
-| Tool                      | Description                                             | Credentials   |
-| ------------------------- | ------------------------------------------------------- | ------------- |
-| `search_content`          | Search LumApps content (titles, excerpts, `content_id`) | read (all.read) |
-| `get_content_body`        | Get full article body by `content_id`                   | read          |
-| `find_person`             | Search people in the directory                          | read          |
-| `get_useful_links`        | Search useful links (Directory Entries: train, IT, training, etc.) | read          |
-| `search_site`             | List or search LumApps sites (instances) for discovery and user confirmation | read          |
-| `inspect_lumapps_element` | Inspect page layout or site global CSS (API only)       | read          |
-| `update_global_css`           | Update site global CSS                                  | admin (all.admin) |
-| `update_widget_style`         | Update a widget's style on a page                       | admin             |
-| `update_site_global_settings` | Update site footer HTML and/or head scripts             | admin             |
+| Tool                          | Description                                                                  | Credentials       |
+| ----------------------------- | ---------------------------------------------------------------------------- | ----------------- |
+| `search_content`              | Search LumApps content (titles, excerpts, `content_id`)                      | read (all.read)   |
+| `get_content_body`            | Get full article body by `content_id`                                        | read              |
+| `find_person`                 | Search people in the directory                                               | read              |
+| `get_useful_links`            | Search useful links (Directory Entries: train, IT, training, etc.)           | read              |
+| `search_site`                 | List or search LumApps sites (instances) for discovery and user confirmation | read              |
+| `inspect_lumapps_element`     | Inspect page layout or site global CSS (API only)                            | read              |
+| `update_global_css`           | Update site global CSS                                                       | admin (all.admin) |
+| `update_widget_style`         | Update a widget's style on a page                                            | admin             |
+| `update_site_global_settings` | Update site footer HTML and/or head scripts                                  | admin             |
 
 Read tools use the **read** LumApps app (`LUMAPPS_READ_CLIENT_ID`/`LUMAPPS_READ_CLIENT_SECRET` or `LUMAPPS_CLIENT_ID`/`LUMAPPS_CLIENT_SECRET`); modification tools use the **admin** app (`LUMAPPS_ADMIN_CLIENT_ID`/`LUMAPPS_ADMIN_CLIENT_SECRET`) when configured. See [Read vs admin credentials](#read-vs-admin-credentials). When [user-level RBAC](#user-level-rbac) is enabled, **Structural** tools (CSS, layout, global settings) also require the authenticated user to have Site Administrator role for the target site; **Content** tools (when added) require Contributor or Admin. API key alone cannot run Structural or Content tools.
 
@@ -195,8 +195,8 @@ Static or semi-static documentation exposed as MCP resources (clients can list a
 | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | `lumapps://lumapps-mcp-server/css-variables`             | LumApps CSS variables reference (static doc).                                                                 |
 | `lumapps://lumapps-mcp-server/layout-and-widget-styling` | Layout (rows, cells, sticky), row/cell and widget styles (spacing, border, background, header/footer, hover). |
-| `lumapps://lumapps-mcp-server/style-and-theme`          | Site style (theme): structure, properties, stylesheets, footer/head, style/save flow.                         |
-| `lumapps://lumapps-mcp-server/customizations-api`      | Customizations API: JavaScript (targets, placements, components) and CSS (anchors, best practices).         |
+| `lumapps://lumapps-mcp-server/style-and-theme`           | Site style (theme): structure, properties, stylesheets, footer/head, style/save flow.                         |
+| `lumapps://lumapps-mcp-server/customizations-api`        | Customizations API: JavaScript (targets, placements, components) and CSS (anchors, best practices).           |
 
 Content is stored in `app/resources/` and can be updated without code changes.
 
@@ -243,14 +243,14 @@ Videos are in **`assets/videos/`** (tracked with Git LFS). Main recap:
   Your browser does not support the video tag.
 </video>
 
-| Feature | Video |
-| -------- | ----- |
-| **Search** | [01-deep-content-search.mp4](assets/videos/01-deep-content-search.mp4) |
-| **People** | [02-people-expertise-discovery.mp4](assets/videos/02-people-expertise-discovery.mp4) |
-| **Links** | [03-smart-intent-links.mp4](assets/videos/03-smart-intent-links.mp4) |
-| **Drafting** | [04-ai-content-drafting.mp4](assets/videos/04-ai-content-drafting.mp4) |
-| **Design** | [05-visual-layout-engineering.mp4](assets/videos/05-visual-layout-engineering.mp4) |
-| **Architect** | [06-global-site-architecture.mp4](assets/videos/06-global-site-architecture.mp4) |
+| Feature       | Video                                                                                |
+| ------------- | ------------------------------------------------------------------------------------ |
+| **Search**    | [01-deep-content-search.mp4](assets/videos/01-deep-content-search.mp4)               |
+| **People**    | [02-people-expertise-discovery.mp4](assets/videos/02-people-expertise-discovery.mp4) |
+| **Links**     | [03-smart-intent-links.mp4](assets/videos/03-smart-intent-links.mp4)                 |
+| **Drafting**  | [04-ai-content-drafting.mp4](assets/videos/04-ai-content-drafting.mp4)               |
+| **Design**    | [05-visual-layout-engineering.mp4](assets/videos/05-visual-layout-engineering.mp4)   |
+| **Architect** | [06-global-site-architecture.mp4](assets/videos/06-global-site-architecture.mp4)     |
 
 ---
 
@@ -285,4 +285,4 @@ Contributions are welcome (issues, pull requests). Please read [CONTRIBUTING.md]
 
 ---
 
-*Disclaimer: This is a community-driven project and is not officially affiliated with or endorsed by LumApps.*
+_Disclaimer: This is a community-driven project and is not officially affiliated with or endorsed by LumApps._

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -57,15 +57,18 @@ class Settings(BaseSettings):
     LOG_LEVEL: str = "INFO"
     MAX_SEARCH_RESULTS: int = 5
 
-    # RBAC: user-level role checks (OIDC claims) for Content/Structural tools
+    # RBAC: user-level role checks
     RBAC_ENABLED: bool = True
+    # When True, use LumApps native permissions (front-init, content/get canEdit, and LumApps token payload isOrgAdmin)
+    RBAC_USE_LUMAPPS_NATIVE: bool = True
+    # Claim in the LumApps user token payload for platform Global Admin (e.g. isOrgAdmin: true)
+    RBAC_ORG_ADMIN_CLAIM: str = "isOrgAdmin"
+    # Only used when RBAC_USE_LUMAPPS_NATIVE is False: OIDC role claim and patterns (ignored when using LumApps native)
     RBAC_ROLE_CLAIM: str = "groups"
-    # Comma-separated patterns; {site_id} is replaced by target site; * matches any site (global admin)
     RBAC_ADMIN_PATTERNS: str = "lumapps:site:{site_id}:admin"
     RBAC_CONTRIBUTOR_PATTERNS: str = "lumapps:site:{site_id}:contributor,lumapps:site:{site_id}:admin"
     RBAC_GLOBAL_ADMIN_PATTERNS: str = "lumapps:site:*:admin,lumapps:global:admin"
     RBAC_DENY_API_KEY_FOR_NON_READ: bool = True
-    # Cache for content_id -> site_id resolution (seconds TTL, max entries)
     RBAC_CONTENT_SITE_CACHE_TTL_SECONDS: int = 300
     RBAC_CONTENT_SITE_CACHE_MAX_SIZE: int = 500
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -57,6 +57,18 @@ class Settings(BaseSettings):
     LOG_LEVEL: str = "INFO"
     MAX_SEARCH_RESULTS: int = 5
 
+    # RBAC: user-level role checks (OIDC claims) for Content/Structural tools
+    RBAC_ENABLED: bool = True
+    RBAC_ROLE_CLAIM: str = "groups"
+    # Comma-separated patterns; {site_id} is replaced by target site; * matches any site (global admin)
+    RBAC_ADMIN_PATTERNS: str = "lumapps:site:{site_id}:admin"
+    RBAC_CONTRIBUTOR_PATTERNS: str = "lumapps:site:{site_id}:contributor,lumapps:site:{site_id}:admin"
+    RBAC_GLOBAL_ADMIN_PATTERNS: str = "lumapps:site:*:admin,lumapps:global:admin"
+    RBAC_DENY_API_KEY_FOR_NON_READ: bool = True
+    # Cache for content_id -> site_id resolution (seconds TTL, max entries)
+    RBAC_CONTENT_SITE_CACHE_TTL_SECONDS: int = 300
+    RBAC_CONTENT_SITE_CACHE_MAX_SIZE: int = 500
+
     @model_validator(mode="after")
     def check_lumapps_auth(self):
         if self.LUMAPPS_ACCESS_TOKEN:

--- a/app/core/rbac.py
+++ b/app/core/rbac.py
@@ -1,0 +1,289 @@
+# Copyright 2026 Joffrey TREBOT (Wheatfield Studio)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+User-level RBAC: tool sensitivity, OIDC role mapping (including Global Admin),
+site resolution with content_id -> site_id cache, and pre-execution authorization.
+"""
+
+import asyncio
+import logging
+import time
+from typing import Any, Dict, List, Literal, Optional, Set, Tuple
+
+from app.core.config import settings
+from app.core.user_context import UserContext, get_user_context
+
+logger = logging.getLogger(__name__)
+
+ToolSensitivity = Literal["read", "content", "structural"]
+
+# Tools that require site Admin (CSS, layout, global settings)
+STRUCTURAL_TOOLS: Set[str] = {
+    "update_global_css",
+    "update_site_global_settings",
+}
+# Tools that allow Contributor or Admin (editing page content, widget style, or inspecting layout/CSS)
+CONTENT_TOOLS: Set[str] = {
+    "update_widget_style",
+    "inspect_lumapps_element",
+}
+# All other tools are read-only
+READ_TOOLS: Set[str] = {
+    "search_content",
+    "search_lumapps",
+    "get_content_body",
+    "find_person",
+    "get_useful_links",
+    "search_site",
+}
+
+
+def get_tool_sensitivity(tool_name: str) -> ToolSensitivity:
+    if tool_name in STRUCTURAL_TOOLS:
+        return "structural"
+    if tool_name in CONTENT_TOOLS:
+        return "content"
+    return "read"
+
+
+class RBACError(Exception):
+    """Raised when a user is not allowed to run a tool. message is safe for end users."""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+        super().__init__(message)
+
+
+def _claim_values_to_strings(claim_value: Any) -> List[str]:
+    """Normalize OIDC claim (list or string) to list of non-empty strings."""
+    if claim_value is None:
+        return []
+    if isinstance(claim_value, str):
+        return [claim_value.strip()] if claim_value.strip() else []
+    if isinstance(claim_value, list):
+        out: List[str] = []
+        for x in claim_value:
+            if isinstance(x, str) and x.strip():
+                out.append(x.strip())
+        return out
+    return []
+
+
+def _parse_pattern_list(csv: str) -> List[str]:
+    return [p.strip() for p in (csv or "").split(",") if p.strip()]
+
+
+def _user_has_global_admin(claims: Dict[str, Any]) -> bool:
+    """
+    Check global admin patterns first (priority over site-scoped).
+    Global admin patterns are matched literally so one token value (e.g. lumapps:site:*:admin
+    or lumapps:global:admin) grants admin on all sites without listing 500 site IDs.
+    """
+    patterns_csv = getattr(settings, "RBAC_GLOBAL_ADMIN_PATTERNS", "") or ""
+    patterns = _parse_pattern_list(patterns_csv)
+    claim_name = getattr(settings, "RBAC_ROLE_CLAIM", "groups") or "groups"
+    values = _claim_values_to_strings(claims.get(claim_name))
+    for v in values:
+        for p in patterns:
+            if v == p:
+                return True
+    return False
+
+
+def _user_has_site_role(
+    claims: Dict[str, Any],
+    site_id: str,
+    required: Literal["admin", "contributor"],
+) -> bool:
+    """
+    Check if user has required role for site_id (after global admin check).
+    Admin implies contributor. Uses {site_id} substitution in configured patterns.
+    """
+    claim_name = getattr(settings, "RBAC_ROLE_CLAIM", "groups") or "groups"
+    values = _claim_values_to_strings(claims.get(claim_name))
+    if not site_id:
+        return False
+
+    if required == "admin":
+        patterns_csv = getattr(settings, "RBAC_ADMIN_PATTERNS", "") or ""
+    else:
+        patterns_csv = getattr(settings, "RBAC_CONTRIBUTOR_PATTERNS", "") or ""
+    patterns = _parse_pattern_list(patterns_csv)
+
+    for pattern in patterns:
+        concrete = pattern.replace("{site_id}", site_id)
+        if concrete in values:
+            return True
+    return False
+
+
+def _user_is_admin_for_site(ctx: UserContext, site_id: str) -> bool:
+    """True if user has global admin or site-scoped admin for site_id."""
+    if _user_has_global_admin(ctx.raw_claims):
+        return True
+    return _user_has_site_role(ctx.raw_claims, site_id, "admin")
+
+
+def _user_is_contributor_or_admin_for_site(ctx: UserContext, site_id: str) -> bool:
+    """True if user has contributor or admin for site_id (or global admin)."""
+    if _user_has_global_admin(ctx.raw_claims):
+        return True
+    if _user_has_site_role(ctx.raw_claims, site_id, "admin"):
+        return True
+    return _user_has_site_role(ctx.raw_claims, site_id, "contributor")
+
+
+# ----- Content ID -> Site ID cache (TTL + max size) -----
+
+class _ContentSiteCache:
+    def __init__(self, ttl_seconds: int = 300, max_size: int = 500):
+        self._ttl = ttl_seconds
+        self._max_size = max_size
+        self._cache: Dict[str, Tuple[str, float]] = {}
+        self._order: List[str] = []
+        self._lock = asyncio.Lock()
+
+    async def get(self, content_id: str) -> Optional[str]:
+        async with self._lock:
+            entry = self._cache.get(content_id)
+            if entry is None:
+                return None
+            site_id, expires_at = entry
+            if time.monotonic() > expires_at:
+                self._cache.pop(content_id, None)
+                if content_id in self._order:
+                    self._order.remove(content_id)
+                return None
+            return site_id
+
+    async def set(self, content_id: str, site_id: str) -> None:
+        async with self._lock:
+            while len(self._cache) >= self._max_size and self._order:
+                evict = self._order.pop(0)
+                self._cache.pop(evict, None)
+            expires_at = time.monotonic() + self._ttl
+            self._cache[content_id] = (site_id, expires_at)
+            if content_id in self._order:
+                self._order.remove(content_id)
+            self._order.append(content_id)
+
+
+_content_site_cache: Optional[_ContentSiteCache] = None
+
+
+def _get_content_site_cache() -> _ContentSiteCache:
+    global _content_site_cache
+    if _content_site_cache is None:
+        ttl = getattr(settings, "RBAC_CONTENT_SITE_CACHE_TTL_SECONDS", 300) or 300
+        max_size = getattr(settings, "RBAC_CONTENT_SITE_CACHE_MAX_SIZE", 500) or 500
+        _content_site_cache = _ContentSiteCache(ttl_seconds=ttl, max_size=max_size)
+    return _content_site_cache
+
+
+async def resolve_target_site_id(
+    tool_name: str,
+    arguments: Dict[str, Any],
+    token: Optional[str] = None,
+) -> Optional[str]:
+    """
+    Resolve the target site_id for the tool. Uses arguments['site_id'] when present.
+    For update_widget_style, resolves content_id -> site_id via get_content (with cache).
+    """
+    site_id = arguments.get("site_id") or arguments.get("siteId")
+    if isinstance(site_id, str) and site_id.strip():
+        return site_id.strip()
+
+    if tool_name in ("update_widget_style", "inspect_lumapps_element"):
+        content_id = arguments.get("content_id")
+        if not content_id or not isinstance(content_id, str) or not content_id.strip():
+            return None
+        content_id = content_id.strip()
+        cache = _get_content_site_cache()
+        cached = await cache.get(content_id)
+        if cached is not None:
+            return cached
+        if token:
+            from app.services.lumapps_client import lumapps_client
+            try:
+                content = await lumapps_client.get_content(content_id, token=token)
+            except Exception as e:
+                logger.warning("resolve_target_site_id get_content failed: %s", e)
+                return None
+            instance = content.get("instance")
+            if isinstance(instance, dict):
+                resolved = (instance.get("uid") or instance.get("id")) if instance else None
+            else:
+                resolved = instance
+            if isinstance(resolved, str) and resolved.strip():
+                await cache.set(content_id, resolved.strip())
+                return resolved.strip()
+        return None
+    return None
+
+
+async def authorize_tool_call(
+    tool_name: str,
+    arguments: Dict[str, Any],
+    *,
+    token: Optional[str] = None,
+) -> None:
+    """
+    Enforce user-level RBAC. Raises RBACError with a secure message if not allowed.
+    When RBAC is disabled, returns without raising.
+    token: optional read token for content_id -> site_id resolution (e.g. update_widget_style).
+    """
+    if not getattr(settings, "RBAC_ENABLED", True):
+        return
+
+    sensitivity = get_tool_sensitivity(tool_name)
+    if sensitivity == "read":
+        return
+
+    ctx = get_user_context()
+    deny_api_key = getattr(settings, "RBAC_DENY_API_KEY_FOR_NON_READ", True)
+
+    if ctx is None:
+        if deny_api_key:
+            raise RBACError(
+                "This action requires an authenticated user identity (OIDC SSO). "
+                "API key alone cannot perform content or design changes."
+            )
+        return
+
+    # CONTENT and STRUCTURAL require a resolvable site for role check
+    if sensitivity == "structural":
+        site_id = await resolve_target_site_id(tool_name, arguments, token=token)
+        if not site_id:
+            raise RBACError(
+                "Could not determine the target site for this action. "
+                "Provide site_id (or content_id for widget updates) and try again."
+            )
+        if not _user_is_admin_for_site(ctx, site_id):
+            raise RBACError(
+                "You have rights to edit content, but global design and architecture changes "
+                "require Site Administrator privileges for this site."
+            )
+    else:
+        # CONTENT: require contributor or admin for site (e.g. update_widget_style targets a page/site)
+        site_id = await resolve_target_site_id(tool_name, arguments, token=token)
+        if not site_id:
+            raise RBACError(
+                "Could not determine the target site for this action. "
+                "Provide content_id (and ensure the page exists) so your role can be verified."
+            )
+        if not _user_is_contributor_or_admin_for_site(ctx, site_id):
+            raise RBACError(
+                "You do not have Contributor or Administrator rights for this site."
+            )

--- a/app/core/rbac.py
+++ b/app/core/rbac.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 """
-User-level RBAC: tool sensitivity, OIDC role mapping (including Global Admin),
-site resolution with content_id -> site_id cache, and pre-execution authorization.
+User-level RBAC: tool sensitivity and authorization.
+Uses LumApps native permissions (front-init instancesSuperAdmin, content/get canEdit)
+and LumApps token payload isOrgAdmin when RBAC_USE_LUMAPPS_NATIVE is True; otherwise OIDC role patterns.
 """
 
 import asyncio
@@ -129,15 +130,60 @@ def _user_has_site_role(
     return False
 
 
+def _lumapps_token_is_org_admin(lumapps_token: str) -> bool:
+    """
+    True if the LumApps user token payload contains the Global Admin flag (e.g. isOrgAdmin: true).
+    Source: payload of the token obtained via impersonation (OAuth2 + user email), not OIDC.
+    """
+    if not lumapps_token or not isinstance(lumapps_token, str):
+        return False
+    claim_name = getattr(settings, "RBAC_ORG_ADMIN_CLAIM", "isOrgAdmin") or "isOrgAdmin"
+    try:
+        import jwt
+        payload = jwt.decode(lumapps_token, options={"verify_signature": False})
+        val = payload.get(claim_name)
+        return val is True or (isinstance(val, str) and val.lower() in ("true", "1"))
+    except Exception:
+        return False
+
+
+async def _user_is_site_admin_lumapps(token: str, site_id: str) -> bool:
+    """
+    True if user (impersonated by token) is Site Admin for site_id or Global Admin.
+    Uses LumApps GET service/front-init?fields=user -> instancesSuperAdmin, isSuperAdmin.
+    """
+    from app.services.lumapps_client import lumapps_client
+    try:
+        user = await lumapps_client.get_front_init_user(token)
+    except Exception as e:
+        logger.warning("RBAC front-init failed: %s", e)
+        return False
+    if user.get("isSuperAdmin") is True:
+        return True
+    instances = user.get("instancesSuperAdmin") or []
+    if not isinstance(instances, list):
+        return False
+    return site_id in instances or any(str(s) == site_id for s in instances)
+
+
+async def _content_can_edit_lumapps(token: str, content_id: str) -> bool:
+    """
+    True if user (impersonated by token) can edit this content (page).
+    Uses LumApps content/get?uid=...&fields=canEdit.
+    """
+    from app.services.lumapps_client import lumapps_client
+    return await lumapps_client.get_content_can_edit(content_id, token)
+
+
 def _user_is_admin_for_site(ctx: UserContext, site_id: str) -> bool:
-    """True if user has global admin or site-scoped admin for site_id."""
+    """True if user has global admin or site-scoped admin for site_id (OIDC patterns only)."""
     if _user_has_global_admin(ctx.raw_claims):
         return True
     return _user_has_site_role(ctx.raw_claims, site_id, "admin")
 
 
 def _user_is_contributor_or_admin_for_site(ctx: UserContext, site_id: str) -> bool:
-    """True if user has contributor or admin for site_id (or global admin)."""
+    """True if user has contributor or admin for site_id (OIDC patterns only)."""
     if _user_has_global_admin(ctx.raw_claims):
         return True
     if _user_has_site_role(ctx.raw_claims, site_id, "admin"):
@@ -242,7 +288,7 @@ async def authorize_tool_call(
     """
     Enforce user-level RBAC. Raises RBACError with a secure message if not allowed.
     When RBAC is disabled, returns without raising.
-    token: optional read token for content_id -> site_id resolution (e.g. update_widget_style).
+    token: optional LumApps user token used by native RBAC checks and site resolution.
     """
     if not getattr(settings, "RBAC_ENABLED", True):
         return
@@ -262,7 +308,56 @@ async def authorize_tool_call(
             )
         return
 
-    # CONTENT and STRUCTURAL require a resolvable site for role check
+    use_native = getattr(settings, "RBAC_USE_LUMAPPS_NATIVE", True)
+
+    # A. Global Admin (Platform): isOrgAdmin in LumApps user token payload — allow without further checks
+    if use_native and token and _lumapps_token_is_org_admin(token):
+        return
+
+    # In native mode, fail closed when user token is unavailable.
+    # Fallback OIDC patterns are only for RBAC_USE_LUMAPPS_NATIVE=false.
+    if use_native and not token:
+        raise RBACError(
+            "Could not verify your LumApps permissions for this action. "
+            "Make sure user impersonation credentials are configured and try again."
+        )
+
+    if use_native and token:
+        site_id = await resolve_target_site_id(tool_name, arguments, token=token)
+
+        if sensitivity == "structural":
+            if not site_id:
+                raise RBACError(
+                    "Could not determine the target site for this action. "
+                    "Provide site_id (or content_id for widget updates) and try again."
+                )
+            if await _user_is_site_admin_lumapps(token, site_id):
+                return
+            raise RBACError(
+                "You have rights to edit content, but global design and architecture changes "
+                "require Site Administrator privileges for this site."
+            )
+
+        # CONTENT: canEdit for the page, or Site Admin when only site_id (e.g. inspect global CSS)
+        content_id = (arguments.get("content_id") or "").strip() if isinstance(arguments.get("content_id"), str) else None
+        if content_id:
+            if await _content_can_edit_lumapps(token, content_id):
+                return
+            raise RBACError(
+                "You do not have permission to edit this page. Only users with edit rights on this content can use this action."
+            )
+        if site_id and await _user_is_site_admin_lumapps(token, site_id):
+            return
+        if not site_id:
+            raise RBACError(
+                "Could not determine the target site or content for this action. "
+                "Provide content_id or site_id so your role can be verified."
+            )
+        raise RBACError(
+            "You do not have Contributor or Administrator rights for this site."
+        )
+
+    # Fallback: OIDC role patterns (no LumApps API calls)
     if sensitivity == "structural":
         site_id = await resolve_target_site_id(tool_name, arguments, token=token)
         if not site_id:
@@ -276,7 +371,6 @@ async def authorize_tool_call(
                 "require Site Administrator privileges for this site."
             )
     else:
-        # CONTENT: require contributor or admin for site (e.g. update_widget_style targets a page/site)
         site_id = await resolve_target_site_id(tool_name, arguments, token=token)
         if not site_id:
             raise RBACError(

--- a/app/services/lumapps_client.py
+++ b/app/services/lumapps_client.py
@@ -89,7 +89,38 @@ class LumAppsClient:
         logger.info(f"LumApps API returned {len(items)} items.")
         return items
 
-    async def get_content(self, content_id: str, token: str, lang: str = None) -> Dict[str, Any]:
+    async def get_front_init_user(self, token: str) -> Dict[str, Any]:
+        """
+        Get current user context from LumApps front-init (impersonated by token).
+        GET service/front-init?fields=user
+        Returns: { "user": { "instancesSuperAdmin": ["id1", "id2"], "isSuperAdmin": bool } }
+        Used for RBAC: site admin list and global admin flag.
+        """
+        path = "service/front-init"
+        params = {"fields": "user"}
+        try:
+            data = await self._request("GET", path, token=token, params=params)
+            return data.get("user") or {}
+        except httpx.HTTPStatusError as e:
+            logger.warning("front-init user failed: %s %s", e.response.status_code, e.response.text[:200] if e.response.text else "")
+            raise
+
+    async def get_content_can_edit(self, content_id: str, token: str) -> bool:
+        """
+        Check if the current user (impersonated by token) can edit this content (page).
+        GET _ah/api/lumsites/v1/content/get?uid=...&fields=canEdit
+        Returns True only when canEdit is true in the response.
+        """
+        path = "_ah/api/lumsites/v1/content/get"
+        params = {"uid": content_id, "fields": "canEdit"}
+        try:
+            data = await self._request("GET", path, token=token, params=params)
+            return bool(data.get("canEdit") is True)
+        except httpx.HTTPStatusError as e:
+            logger.warning("content/get canEdit failed for %s: %s", content_id, e.response.status_code)
+            return False
+
+    async def get_content(self, content_id: str, token: str, lang: str = None, fields: str = None) -> Dict[str, Any]:
         """
         Get a single content (page) by uid. Returns the full content object.
         GET _ah/api/lumsites/v1/content/get?uid=...
@@ -101,7 +132,9 @@ class LumAppsClient:
         params = {"uid": content_id}
         if lang:
             params["lang"] = lang
-        
+        if fields:
+            params["fields"] = fields
+
         try:
             return await self._request("GET", path, token=token, params=params)
         except httpx.HTTPStatusError as e:

--- a/app/tools/__init__.py
+++ b/app/tools/__init__.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, Callable, Awaitable
 
 from app.jsonrpc.dispatcher import dispatcher
 from app.core.user_context import get_user_context
+from app.core.rbac import authorize_tool_call, get_tool_sensitivity, RBACError
 import logging
 
 from app.tools import (
@@ -89,6 +90,19 @@ def _resolve_user_email(arguments: Dict[str, Any]) -> Dict[str, Any]:
     return arguments
 
 
+async def _get_read_token_for_rbac(arguments: Dict[str, Any]) -> Any:
+    """Optional read token for content_id -> site_id resolution in RBAC (structural and content tools)."""
+    from app.services.lumapps_auth import lumapps_auth
+    user_email = (arguments.get("user_email") or "").strip()
+    if not user_email:
+        return None
+    try:
+        return await lumapps_auth.get_token(user_email=user_email, profile="read")
+    except Exception as e:
+        logger.debug("RBAC: could not get read token for site resolution: %s", e)
+        return None
+
+
 @dispatcher.register("tools/call")
 async def tools_call(params: Any) -> Dict[str, Any]:
     """Dispatch by tool name to the registered handler."""
@@ -100,6 +114,14 @@ async def tools_call(params: Any) -> Dict[str, Any]:
         available = sorted({s["name"] for s, _ in TOOLS.values()})
         raise ValueError(f"Unknown tool: {name}. Available: {', '.join(available)}")
     arguments = _resolve_user_email(arguments)
+    token = None
+    sensitivity = get_tool_sensitivity(name)
+    if sensitivity in ("structural", "content") and arguments.get("user_email"):
+        token = await _get_read_token_for_rbac(arguments)
+    try:
+        await authorize_tool_call(name, arguments, token=token)
+    except RBACError as e:
+        raise ValueError(e.message)
     _schema, handler = TOOLS[name]
     return await handler(arguments)
 

--- a/app/tools/api_error_utils.py
+++ b/app/tools/api_error_utils.py
@@ -17,6 +17,24 @@
 import httpx
 from tenacity import RetryError
 
+# Message returned when LumApps denies write (403/401) so we don't leak API details
+PERMISSION_DENIED_MESSAGE = (
+    "This action was denied by the platform. "
+    "Global design and architecture changes require Site Administrator privileges for this site."
+)
+
+
+def is_permission_denied(exc: BaseException) -> bool:
+    """True if the exception looks like an HTTP permission-denied (401/403)."""
+    cause = exc
+    if isinstance(exc, RetryError) and getattr(exc, "last_attempt", None):
+        attempt = exc.last_attempt
+        if getattr(attempt, "failed", False) and getattr(attempt, "outcome", None):
+            cause = attempt.outcome.exception() or exc
+    if isinstance(cause, httpx.HTTPStatusError):
+        return cause.response.status_code in (401, 403)
+    return False
+
 
 def format_api_error(exc: BaseException, max_body: int = 600) -> str:
     """Extract a clear message from API errors (HTTPStatusError or RetryError wrapping it)."""

--- a/app/tools/inspect_lumapps_element.py
+++ b/app/tools/inspect_lumapps_element.py
@@ -172,7 +172,7 @@ async def handle(arguments: Dict[str, Any]) -> Dict[str, Any]:
     if content_id:
         logger.info(f"Executing inspect_lumapps_element (layout) content_id={content_id!r}, user_email={user_email!r}")
         try:
-            token = await lumapps_auth.get_token(user_email=user_email)
+            token = await lumapps_auth.get_token(user_email=user_email, profile="admin")
             layout = await lumapps_client.get_content_layout(content_id, token=token)
             text = _format_layout_response(layout)
             return {"content": [{"type": "text", "text": text}]}
@@ -190,7 +190,7 @@ async def handle(arguments: Dict[str, Any]) -> Dict[str, Any]:
     if site_id:
         logger.info(f"Executing inspect_lumapps_element (style) site_id={site_id!r}, user_email={user_email!r}")
         try:
-            token = await lumapps_auth.get_token(user_email=user_email)
+            token = await lumapps_auth.get_token(user_email=user_email, profile="admin")
             data = await lumapps_client.get_style_by_instance(site_id, token=token)
             style = data.get("style")
             if not style:

--- a/app/tools/update_global_css.py
+++ b/app/tools/update_global_css.py
@@ -19,7 +19,7 @@ from datetime import datetime, timezone
 import logging
 
 from app.core.config import settings
-from app.tools.api_error_utils import format_api_error
+from app.tools.api_error_utils import format_api_error, is_permission_denied, PERMISSION_DENIED_MESSAGE
 from app.services.lumapps_auth import lumapps_auth
 from app.services.lumapps_client import lumapps_client
 
@@ -129,10 +129,9 @@ async def handle(arguments: Dict[str, Any]) -> Dict[str, Any]:
         await lumapps_client.save_style(style, token=token)
     except Exception as e:
         logger.exception("update_global_css save_style failed")
+        text = PERMISSION_DENIED_MESSAGE if is_permission_denied(e) else f"Could not save style: {format_api_error(e)}."
         return {
-            "content": [
-                {"type": "text", "text": f"Could not save style: {format_api_error(e)}."}
-            ]
+            "content": [{"type": "text", "text": text}]
         }
 
     base_url = (settings.SITE_BASE_URL or "").rstrip("/")

--- a/app/tools/update_site_global_settings.py
+++ b/app/tools/update_site_global_settings.py
@@ -18,7 +18,7 @@ from typing import Any, Dict
 import logging
 
 from app.core.config import settings
-from app.tools.api_error_utils import format_api_error
+from app.tools.api_error_utils import format_api_error, is_permission_denied, PERMISSION_DENIED_MESSAGE
 from app.services.lumapps_auth import lumapps_auth
 from app.services.lumapps_client import lumapps_client
 
@@ -173,13 +173,9 @@ async def handle(arguments: Dict[str, Any]) -> Dict[str, Any]:
             await lumapps_client.save_style(style, token=token)
         except Exception as e:
             logger.exception("update_site_global_settings save_style failed")
+            text = PERMISSION_DENIED_MESSAGE if is_permission_denied(e) else f"Could not save style: {format_api_error(e)}."
             return {
-                "content": [
-                    {
-                        "type": "text",
-                        "text": f"Could not save style: {format_api_error(e)}.",
-                    }
-                ]
+                "content": [{"type": "text", "text": text}]
             }
         messages.append(f"Footer updated for locales: {', '.join(sorted(merged_footer.keys()))}.")
 
@@ -214,13 +210,9 @@ async def handle(arguments: Dict[str, Any]) -> Dict[str, Any]:
             await lumapps_client.save_instance(instance, token=token)
         except Exception as e:
             logger.exception("update_site_global_settings save_instance failed")
+            text = PERMISSION_DENIED_MESSAGE if is_permission_denied(e) else f"Could not save instance (head): {format_api_error(e)}."
             return {
-                "content": [
-                    {
-                        "type": "text",
-                        "text": f"Could not save instance (head): {format_api_error(e)}.",
-                    }
-                ]
+                "content": [{"type": "text", "text": text}]
             }
         messages.append("Head updated (script(s) added).")
 

--- a/app/tools/update_widget_style.py
+++ b/app/tools/update_widget_style.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Tuple
 
 from app.services.lumapps_auth import lumapps_auth
 from app.services.lumapps_client import lumapps_client
+from app.tools.api_error_utils import is_permission_denied, PERMISSION_DENIED_MESSAGE
 
 logger = logging.getLogger(__name__)
 
@@ -157,13 +158,15 @@ async def handle(arguments: Dict[str, Any]) -> Dict[str, Any]:
         layout = await lumapps_client.get_content_layout(content_id, token=token)
     except Exception as e:
         logger.exception("get_content_layout failed")
-        return {"content": [{"type": "text", "text": f"Failed to load layout: {e}"}]}
+        text = PERMISSION_DENIED_MESSAGE if is_permission_denied(e) else f"Failed to load layout: {e}"
+        return {"content": [{"type": "text", "text": text}]}
 
     try:
         ok, msg = await _save_via_content(content_id, widget_id, style_updates, token, layout)
     except Exception as e:
         logger.exception("save via content failed")
-        return {"content": [{"type": "text", "text": f"Save failed: {e}"}]}
+        text = PERMISSION_DENIED_MESSAGE if is_permission_denied(e) else f"Save failed: {e}"
+        return {"content": [{"type": "text", "text": text}]}
 
     if not ok:
         return {"content": [{"type": "text", "text": msg}]}

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -28,3 +28,11 @@ data:
   # CORS_ORIGINS: ""
   # Optional: user directory module id for find_person enrichment
   # LUMAPPS_USER_DIRECTORY_ID: ""
+  # Optional: RBAC (user-level roles). See README User-level RBAC.
+  # RBAC_ENABLED: "true"
+  # RBAC_ROLE_CLAIM: "groups"
+  # RBAC_ADMIN_PATTERNS: "lumapps:site:{site_id}:admin"
+  # RBAC_GLOBAL_ADMIN_PATTERNS: "lumapps:site:*:admin,lumapps:global:admin"
+  # RBAC_DENY_API_KEY_FOR_NON_READ: "true"
+  # RBAC_CONTENT_SITE_CACHE_TTL_SECONDS: "300"
+  # RBAC_CONTENT_SITE_CACHE_MAX_SIZE: "500"

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -28,11 +28,10 @@ data:
   # CORS_ORIGINS: ""
   # Optional: user directory module id for find_person enrichment
   # LUMAPPS_USER_DIRECTORY_ID: ""
-  # Optional: RBAC (user-level roles). See README User-level RBAC.
+  # Optional: RBAC. See README User-level RBAC. Native mode: LumApps front-init + content/get canEdit + isOrgAdmin in LumApps token payload.
   # RBAC_ENABLED: "true"
-  # RBAC_ROLE_CLAIM: "groups"
-  # RBAC_ADMIN_PATTERNS: "lumapps:site:{site_id}:admin"
-  # RBAC_GLOBAL_ADMIN_PATTERNS: "lumapps:site:*:admin,lumapps:global:admin"
+  # RBAC_USE_LUMAPPS_NATIVE: "true"
+  # RBAC_ORG_ADMIN_CLAIM: "isOrgAdmin"
   # RBAC_DENY_API_KEY_FOR_NON_READ: "true"
   # RBAC_CONTENT_SITE_CACHE_TTL_SECONDS: "300"
   # RBAC_CONTENT_SITE_CACHE_MAX_SIZE: "500"

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -1,0 +1,244 @@
+# Copyright 2026 Joffrey TREBOT (Wheatfield Studio)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RBAC: API-key deny for non-read tools, OIDC role mapping, site resolution, cache."""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from fastapi.testclient import TestClient
+
+from app.core.rbac import (
+    RBACError,
+    get_tool_sensitivity,
+    resolve_target_site_id,
+    authorize_tool_call,
+    _user_has_global_admin,
+    _user_has_site_role,
+    _get_content_site_cache,
+)
+from app.core.user_context import UserContext
+
+
+def test_get_tool_sensitivity() -> None:
+    assert get_tool_sensitivity("search_content") == "read"
+    assert get_tool_sensitivity("search_lumapps") == "read"
+    assert get_tool_sensitivity("inspect_lumapps_element") == "content"
+    assert get_tool_sensitivity("update_global_css") == "structural"
+    assert get_tool_sensitivity("update_site_global_settings") == "structural"
+    assert get_tool_sensitivity("update_widget_style") == "content"
+    assert get_tool_sensitivity("unknown_tool") == "read"
+
+
+def test_structural_tool_with_api_key_denied(client: TestClient) -> None:
+    """Structural tools with API key only (no OIDC) are denied when RBAC_DENY_API_KEY_FOR_NON_READ is true."""
+    r = client.post(
+        "/mcp",
+        headers={"X-API-Key": "test-mcp-api-key"},
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "update_global_css",
+                "arguments": {
+                    "site_id": "site-123",
+                    "new_css": "/* test */ body {}",
+                    "user_email": "dev@example.com",
+                },
+            },
+        },
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert "error" in data
+    assert data["error"]["message"]
+    assert "OIDC" in data["error"]["message"] or "authenticated user" in data["error"]["message"].lower()
+
+
+def test_read_tool_with_api_key_allowed(client: TestClient) -> None:
+    """Read-only MCP methods (e.g. tools/list) succeed with API key."""
+    r = client.post(
+        "/mcp",
+        headers={"X-API-Key": "test-mcp-api-key"},
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {},
+        },
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert "result" in data
+    assert "tools" in data["result"]
+
+
+def test_authorize_structural_denied_without_user_context() -> None:
+    """When get_user_context() is None and RBAC denies API key, authorize_tool_call raises RBACError."""
+    mock_settings = MagicMock()
+    mock_settings.RBAC_ENABLED = True
+    mock_settings.RBAC_DENY_API_KEY_FOR_NON_READ = True
+    with patch("app.core.rbac.get_user_context", return_value=None):
+        with patch("app.core.rbac.settings", mock_settings):
+            with pytest.raises(RBACError) as exc_info:
+                asyncio.run(authorize_tool_call("update_global_css", {"site_id": "s1", "user_email": "u@x.com"}))
+            assert "OIDC" in exc_info.value.message or "authenticated user" in exc_info.value.message.lower()
+
+
+def test_authorize_structural_denied_contributor_only() -> None:
+    """User with contributor claim for site but not admin is denied for structural tool."""
+    ctx = UserContext(
+        sub="sub1",
+        email="u@example.com",
+        upn="u@example.com",
+        issuer="https://issuer",
+        audience="aud",
+        scopes=[],
+        raw_claims={"groups": ["lumapps:site:site-abc:contributor"]},
+    )
+    mock_settings = MagicMock()
+    mock_settings.RBAC_ENABLED = True
+    mock_settings.RBAC_ADMIN_PATTERNS = "lumapps:site:{site_id}:admin"
+    mock_settings.RBAC_GLOBAL_ADMIN_PATTERNS = "lumapps:site:*:admin,lumapps:global:admin"
+    mock_settings.RBAC_ROLE_CLAIM = "groups"
+    with patch("app.core.rbac.get_user_context", return_value=ctx):
+        with patch("app.core.rbac.settings", mock_settings):
+            with pytest.raises(RBACError) as exc_info:
+                asyncio.run(authorize_tool_call("update_global_css", {"site_id": "site-abc", "user_email": "u@example.com"}))
+            assert "Site Administrator" in exc_info.value.message or "design" in exc_info.value.message.lower()
+
+
+def test_authorize_content_allowed_contributor() -> None:
+    """User with contributor (no admin) claim is allowed for content tools (update_widget_style, inspect_lumapps_element)."""
+    ctx = UserContext(
+        sub="sub1",
+        email="contrib@example.com",
+        upn="contrib@example.com",
+        issuer="https://issuer",
+        audience="aud",
+        scopes=[],
+        raw_claims={"groups": ["lumapps:site:site-abc:contributor"]},
+    )
+    mock_settings = MagicMock()
+    mock_settings.RBAC_ENABLED = True
+    mock_settings.RBAC_ADMIN_PATTERNS = "lumapps:site:{site_id}:admin"
+    mock_settings.RBAC_CONTRIBUTOR_PATTERNS = "lumapps:site:{site_id}:contributor,lumapps:site:{site_id}:admin"
+    mock_settings.RBAC_GLOBAL_ADMIN_PATTERNS = "lumapps:site:*:admin"
+    mock_settings.RBAC_ROLE_CLAIM = "groups"
+    with patch("app.core.rbac.get_user_context", return_value=ctx):
+        with patch("app.core.rbac.settings", mock_settings):
+            asyncio.run(authorize_tool_call(
+                "update_widget_style",
+                {"site_id": "site-abc", "user_email": "contrib@example.com"},
+            ))
+            asyncio.run(authorize_tool_call(
+                "inspect_lumapps_element",
+                {"site_id": "site-abc", "user_email": "contrib@example.com"},
+            ))
+
+
+def test_authorize_structural_allowed_site_admin() -> None:
+    """User with site-scoped admin claim is allowed for structural tool."""
+    ctx = UserContext(
+        sub="sub1",
+        email="u@example.com",
+        upn="u@example.com",
+        issuer="https://issuer",
+        audience="aud",
+        scopes=[],
+        raw_claims={"groups": ["lumapps:site:site-xyz:admin"]},
+    )
+    mock_settings = MagicMock()
+    mock_settings.RBAC_ENABLED = True
+    mock_settings.RBAC_ADMIN_PATTERNS = "lumapps:site:{site_id}:admin"
+    mock_settings.RBAC_GLOBAL_ADMIN_PATTERNS = "lumapps:site:*:admin"
+    mock_settings.RBAC_ROLE_CLAIM = "groups"
+    with patch("app.core.rbac.get_user_context", return_value=ctx):
+        with patch("app.core.rbac.settings", mock_settings):
+            asyncio.run(authorize_tool_call("update_global_css", {"site_id": "site-xyz", "user_email": "u@example.com"}))
+
+
+def test_authorize_structural_allowed_global_admin() -> None:
+    """User with global admin claim (lumapps:site:*:admin) is allowed for any site."""
+    ctx = UserContext(
+        sub="sub1",
+        email="admin@example.com",
+        upn="admin@example.com",
+        issuer="https://issuer",
+        audience="aud",
+        scopes=[],
+        raw_claims={"groups": ["lumapps:site:*:admin"]},
+    )
+    mock_settings = MagicMock()
+    mock_settings.RBAC_ENABLED = True
+    mock_settings.RBAC_ADMIN_PATTERNS = "lumapps:site:{site_id}:admin"
+    mock_settings.RBAC_GLOBAL_ADMIN_PATTERNS = "lumapps:site:*:admin,lumapps:global:admin"
+    mock_settings.RBAC_ROLE_CLAIM = "groups"
+    with patch("app.core.rbac.get_user_context", return_value=ctx):
+        with patch("app.core.rbac.settings", mock_settings):
+            asyncio.run(authorize_tool_call("update_global_css", {"site_id": "any-site", "user_email": "admin@example.com"}))
+
+
+def test_user_has_global_admin() -> None:
+    """Global admin is true when groups contain literal global admin pattern."""
+    assert _user_has_global_admin({"groups": ["lumapps:site:*:admin"]}) is True
+    assert _user_has_global_admin({"groups": ["lumapps:global:admin"]}) is True
+    assert _user_has_global_admin({"groups": ["lumapps:site:site1:admin"]}) is False
+    assert _user_has_global_admin({"groups": []}) is False
+
+
+def test_user_has_site_role() -> None:
+    """Site-scoped admin/contributor match after {site_id} substitution."""
+    with patch("app.core.rbac.settings") as s:
+        s.RBAC_ROLE_CLAIM = "groups"
+        s.RBAC_ADMIN_PATTERNS = "lumapps:site:{site_id}:admin"
+        s.RBAC_CONTRIBUTOR_PATTERNS = "lumapps:site:{site_id}:contributor,lumapps:site:{site_id}:admin"
+        assert _user_has_site_role({"groups": ["lumapps:site:site-1:admin"]}, "site-1", "admin") is True
+        assert _user_has_site_role({"groups": ["lumapps:site:site-1:contributor"]}, "site-1", "contributor") is True
+        assert _user_has_site_role({"groups": ["lumapps:site:site-1:admin"]}, "site-1", "contributor") is True
+        assert _user_has_site_role({"groups": ["lumapps:site:site-1:contributor"]}, "site-1", "admin") is False
+
+
+def test_resolve_target_site_id_from_args() -> None:
+    """resolve_target_site_id returns site_id from arguments when present."""
+    out = asyncio.run(resolve_target_site_id("update_global_css", {"site_id": "my-site-uid"}, token=None))
+    assert out == "my-site-uid"
+    out = asyncio.run(resolve_target_site_id("update_site_global_settings", {"siteId": "other-site"}, token=None))
+    assert out == "other-site"
+
+
+def test_resolve_target_site_id_from_content_id_via_api() -> None:
+    """update_widget_style: content_id -> site_id uses get_content when token provided."""
+    from app.services.lumapps_client import lumapps_client
+    with patch.object(lumapps_client, "get_content", new_callable=AsyncMock, return_value={"instance": "resolved-site-456"}):
+        out = asyncio.run(resolve_target_site_id(
+            "update_widget_style",
+            {"content_id": "content-xyz"},
+            token="fake-token",
+        ))
+    assert out == "resolved-site-456"
+
+
+def test_content_site_cache_hit() -> None:
+    """Cache returns site_id on second resolution for same content_id."""
+    async def _run() -> None:
+        cache = _get_content_site_cache()
+        await cache.set("c1", "site-1")
+        assert await cache.get("c1") == "site-1"
+        assert await cache.get("c2") is None
+        await cache.set("c2", "site-2")
+        assert await cache.get("c2") == "site-2"
+    asyncio.run(_run())

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -98,6 +98,27 @@ def test_authorize_structural_denied_without_user_context() -> None:
             assert "OIDC" in exc_info.value.message or "authenticated user" in exc_info.value.message.lower()
 
 
+def test_authorize_native_mode_denied_without_lumapps_token() -> None:
+    """In native mode, RBAC fails closed when LumApps token is unavailable."""
+    ctx = UserContext(
+        sub="sub1",
+        email="u@example.com",
+        upn="u@example.com",
+        issuer="https://issuer",
+        audience="aud",
+        scopes=[],
+        raw_claims={},
+    )
+    mock_settings = MagicMock()
+    mock_settings.RBAC_ENABLED = True
+    mock_settings.RBAC_USE_LUMAPPS_NATIVE = True
+    with patch("app.core.rbac.get_user_context", return_value=ctx):
+        with patch("app.core.rbac.settings", mock_settings):
+            with pytest.raises(RBACError) as exc_info:
+                asyncio.run(authorize_tool_call("update_global_css", {"site_id": "site-1", "user_email": "u@example.com"}, token=None))
+            assert "Could not verify your LumApps permissions" in exc_info.value.message
+
+
 def test_authorize_structural_denied_contributor_only() -> None:
     """User with contributor claim for site but not admin is denied for structural tool."""
     ctx = UserContext(
@@ -111,6 +132,7 @@ def test_authorize_structural_denied_contributor_only() -> None:
     )
     mock_settings = MagicMock()
     mock_settings.RBAC_ENABLED = True
+    mock_settings.RBAC_USE_LUMAPPS_NATIVE = False
     mock_settings.RBAC_ADMIN_PATTERNS = "lumapps:site:{site_id}:admin"
     mock_settings.RBAC_GLOBAL_ADMIN_PATTERNS = "lumapps:site:*:admin,lumapps:global:admin"
     mock_settings.RBAC_ROLE_CLAIM = "groups"
@@ -134,6 +156,7 @@ def test_authorize_content_allowed_contributor() -> None:
     )
     mock_settings = MagicMock()
     mock_settings.RBAC_ENABLED = True
+    mock_settings.RBAC_USE_LUMAPPS_NATIVE = False
     mock_settings.RBAC_ADMIN_PATTERNS = "lumapps:site:{site_id}:admin"
     mock_settings.RBAC_CONTRIBUTOR_PATTERNS = "lumapps:site:{site_id}:contributor,lumapps:site:{site_id}:admin"
     mock_settings.RBAC_GLOBAL_ADMIN_PATTERNS = "lumapps:site:*:admin"
@@ -163,6 +186,7 @@ def test_authorize_structural_allowed_site_admin() -> None:
     )
     mock_settings = MagicMock()
     mock_settings.RBAC_ENABLED = True
+    mock_settings.RBAC_USE_LUMAPPS_NATIVE = False
     mock_settings.RBAC_ADMIN_PATTERNS = "lumapps:site:{site_id}:admin"
     mock_settings.RBAC_GLOBAL_ADMIN_PATTERNS = "lumapps:site:*:admin"
     mock_settings.RBAC_ROLE_CLAIM = "groups"
@@ -172,7 +196,7 @@ def test_authorize_structural_allowed_site_admin() -> None:
 
 
 def test_authorize_structural_allowed_global_admin() -> None:
-    """User with global admin claim (lumapps:site:*:admin) is allowed for any site."""
+    """User with global admin claim (lumapps:site:*:admin) is allowed for any site (OIDC fallback)."""
     ctx = UserContext(
         sub="sub1",
         email="admin@example.com",
@@ -184,12 +208,41 @@ def test_authorize_structural_allowed_global_admin() -> None:
     )
     mock_settings = MagicMock()
     mock_settings.RBAC_ENABLED = True
+    mock_settings.RBAC_USE_LUMAPPS_NATIVE = False
     mock_settings.RBAC_ADMIN_PATTERNS = "lumapps:site:{site_id}:admin"
     mock_settings.RBAC_GLOBAL_ADMIN_PATTERNS = "lumapps:site:*:admin,lumapps:global:admin"
     mock_settings.RBAC_ROLE_CLAIM = "groups"
     with patch("app.core.rbac.get_user_context", return_value=ctx):
         with patch("app.core.rbac.settings", mock_settings):
             asyncio.run(authorize_tool_call("update_global_css", {"site_id": "any-site", "user_email": "admin@example.com"}))
+
+
+def test_authorize_structural_allowed_lumapps_token_org_admin() -> None:
+    """LumApps user token with isOrgAdmin: true in payload is allowed for all tools (native mode)."""
+    import jwt
+    lumapps_token = jwt.encode({"isOrgAdmin": True, "sub": "u1"}, "dummy", algorithm="HS256")
+    if hasattr(lumapps_token, "decode"):
+        lumapps_token = lumapps_token.decode("utf-8")
+    ctx = UserContext(
+        sub="sub1",
+        email="orgadmin@example.com",
+        upn="orgadmin@example.com",
+        issuer="https://issuer",
+        audience="aud",
+        scopes=[],
+        raw_claims={},
+    )
+    mock_settings = MagicMock()
+    mock_settings.RBAC_ENABLED = True
+    mock_settings.RBAC_USE_LUMAPPS_NATIVE = True
+    mock_settings.RBAC_ORG_ADMIN_CLAIM = "isOrgAdmin"
+    with patch("app.core.rbac.get_user_context", return_value=ctx):
+        with patch("app.core.rbac.settings", mock_settings):
+            asyncio.run(authorize_tool_call(
+                "update_global_css",
+                {"site_id": "any-site", "user_email": "orgadmin@example.com"},
+                token=lumapps_token,
+            ))
 
 
 def test_user_has_global_admin() -> None:


### PR DESCRIPTION
## Summary

This PR finalizes the RBAC hardening for LumApps MCP tools by switching authorization decisions to LumApps-native user permissions and tightening tool-level governance.

- Enforces **native RBAC** flow based on LumApps user impersonation token + LumApps APIs:
  - Global admin from LumApps token payload (`isOrgAdmin`)
  - Site admin from `front-init` (`instancesSuperAdmin` / `isSuperAdmin`)
  - Content edit rights from `content/get?fields=canEdit`
- Reclassifies and enforces tool sensitivity:
  - `inspect_lumapps_element` and `update_widget_style` are treated as **Content** tools
  - Structural tools remain restricted to **Site Admin**
- Makes native mode **fail-closed** when LumApps user token is unavailable (no implicit fallback in native mode)
- Aligns documentation/config naming:
  - `RBAC_ORG_ADMIN_CLAIM` (LumApps token claim source)
  - Clarified OIDC pattern usage as fallback only (`RBAC_USE_LUMAPPS_NATIVE=false`)
- Updates README/CHANGELOG for consistency with real runtime behavior and credentials split (read vs admin apps)

## Why

The previous model could still leave ambiguity between app-level credentials and user-level rights. This change ensures governance-safe behavior: AI actions are executed only when the **actual user** has the corresponding LumApps rights.

## Test plan

- `python3 -m pytest tests/ -q`
- Expected: all tests pass (RBAC + auth regressions)
- Validated key scenarios:
  - API key cannot execute Content/Structural tools
  - Native RBAC checks for content/structural actions
  - Global admin via LumApps token claim
  - Fail-closed behavior when native token is missing
  
Close #3 